### PR TITLE
Removed exception throw on status != 200

### DIFF
--- a/src/main/java/ru/sbtqa/tag/apifactory/rest/RestEntityImpl.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/rest/RestEntityImpl.java
@@ -119,11 +119,6 @@ public class RestEntityImpl extends AbstractRestEntity implements Rest {
 
             HttpResponse response = client.execute(post);
 
-            if (response.getStatusLine().getStatusCode() != 200) {
-                LOG.error("The response status is '{}'", response.getStatusLine().getReasonPhrase());
-                throw new AutotestError("The response status is not 200");
-            }
-
             Map<String, String> headersResponse = new HashMap<>();
             for (Header h : response.getAllHeaders()) {
                 ParamsHelper.addParam(h.getName(), h.getValue());

--- a/src/main/java/ru/sbtqa/tag/apifactory/rest/RestEntityImpl.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/rest/RestEntityImpl.java
@@ -67,11 +67,6 @@ public class RestEntityImpl extends AbstractRestEntity implements Rest {
                 }
             }
 
-            if (response.getStatusLine().getStatusCode() != 200) {
-                LOG.error("The response status is '{}'", response.getStatusLine().getReasonPhrase());
-                throw new AutotestError("The response status is not 200");
-            }
-
             try {
                 bullet = new Bullet(headersResponse,
                         EntityUtils.toString(response.getEntity(), Props.get("api.encoding")));


### PR DESCRIPTION
This solution isn't backward compatible but I think more correct that it is now. Other solutions like following: putting response headers and body into repository before throwing an exception, transfer response's body into the exception, are not acceptable due to current architecture.