### PR TITLE
3.0.1 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ru.sbtqa.tag</groupId>
   <artifactId>api-factory</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>api-factory</name>
   <description>api-factory description</description>
@@ -48,11 +48,11 @@
     </repository>
   </distributionManagement>
   <dependencies>
-  	 <dependency>
-       <groupId>org.springframework</groupId>
-       <artifactId>spring-core</artifactId>
-       <version>4.3.14.RELEASE</version>
-       <type>jar</type>
+  	<dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>4.3.14.RELEASE</version>
+      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>ru.sbtqa.tag</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ru.sbtqa.tag</groupId>
   <artifactId>api-factory</artifactId>
-  <version>3.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>api-factory</name>
   <description>api-factory description</description>
@@ -48,6 +48,12 @@
     </repository>
   </distributionManagement>
   <dependencies>
+  	 <dependency>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-core</artifactId>
+       <version>4.3.14.RELEASE</version>
+       <type>jar</type>
+    </dependency>
     <dependency>
       <groupId>ru.sbtqa.tag</groupId>
       <artifactId>datajack</artifactId>

--- a/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
+++ b/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
@@ -5,6 +5,9 @@ import static java.util.Arrays.asList;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import cucumber.runtime.ClassFinder;
 import cucumber.runtime.Runtime;
 import cucumber.runtime.RuntimeOptions;
@@ -12,6 +15,7 @@ import cucumber.runtime.RuntimeOptions;
 public class CucumberStaticRunner {
 
 	private static String status = "\nFinished: SUCCESS";
+	private static final Logger LOG = LoggerFactory.getLogger(CucumberStaticRunner.class);
 
 	public static void startTests(String[] argv) throws Throwable {
 		byte exitstatus = run(argv, Thread.currentThread().getContextClassLoader());
@@ -28,7 +32,7 @@ public class CucumberStaticRunner {
 		if (runtime.getErrors().size() > 0 || runtime.getSnippets().size() > 0) {
 			status = "Finished: FAILURE";
 		}
-		System.out.println(status);
+		LOG.warn(status);
 		return runtime.exitStatus();
 	}
 }

--- a/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
+++ b/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
@@ -1,0 +1,35 @@
+package cucumber.runtime.io;
+
+import static java.util.Arrays.asList;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import cucumber.runtime.ClassFinder;
+import cucumber.runtime.Runtime;
+import cucumber.runtime.RuntimeOptions;
+
+public class CucumberStaticRunner {
+
+	// private String status = "Finished: FAILURE";
+	private static String status = "\nFinished: SUCCESS";
+
+	public static void startTests(String[] argv) throws Throwable {
+		byte exitstatus = run(argv, Thread.currentThread().getContextClassLoader());
+		System.exit(exitstatus);
+	}
+
+	public static byte run(String[] argv, ClassLoader classLoader) throws IOException {
+		RuntimeOptions runtimeOptions = new RuntimeOptions(new ArrayList<String>(asList(argv)));
+
+		ResourceLoader resourceLoader = new CustomMultiLoader(classLoader);
+		ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
+		Runtime runtime = new Runtime(resourceLoader, classFinder, classLoader, runtimeOptions);
+		runtime.run();
+		if (runtime.getErrors().size() > 0 || runtime.getSnippets().size() > 0) {
+			status = "Finished: FAILURE";
+		}
+		System.out.println(status);
+		return runtime.exitStatus();
+	}
+}

--- a/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
+++ b/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
@@ -11,7 +11,6 @@ import cucumber.runtime.RuntimeOptions;
 
 public class CucumberStaticRunner {
 
-	// private String status = "Finished: FAILURE";
 	private static String status = "\nFinished: SUCCESS";
 
 	public static void startTests(String[] argv) throws Throwable {

--- a/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
+++ b/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
@@ -32,7 +32,7 @@ public class CucumberStaticRunner {
 		if (runtime.getErrors().size() > 0 || runtime.getSnippets().size() > 0) {
 			status = "Finished: FAILURE";
 		}
-		LOG.warn(status);
+		LOG.info(status);
 		return runtime.exitStatus();
 	}
 }

--- a/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
+++ b/src/main/java/cucumber/runtime/io/CucumberStaticRunner.java
@@ -32,7 +32,7 @@ public class CucumberStaticRunner {
 		if (runtime.getErrors().size() > 0 || runtime.getSnippets().size() > 0) {
 			status = "Finished: FAILURE";
 		}
-		LOG.info(status);
+		LOG.warn(status);
 		return runtime.exitStatus();
 	}
 }

--- a/src/main/java/cucumber/runtime/io/CustomMultiLoader.java
+++ b/src/main/java/cucumber/runtime/io/CustomMultiLoader.java
@@ -1,0 +1,62 @@
+package cucumber.runtime.io;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+public class CustomMultiLoader implements ResourceLoader {
+    public static final String CLASSPATH_SCHEME = "classpath*:";
+    public static final String CLASSPATH_SCHEME_TO_REPLACE = "classpath:";
+    private final ClasspathResourceLoader classpath;
+    private final FileResourceLoader fs;
+    public CustomMultiLoader(ClassLoader classLoader) {
+        classpath = new ClasspathResourceLoader(classLoader);
+        fs = new FileResourceLoader();
+    }
+    @Override
+    public Iterable<Resource> resources(String path, String suffix) {
+        if (isClasspathPath(path)) {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            String locationPattern = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME) + "/**/*" + suffix;
+            org.springframework.core.io.Resource[] resources;
+            try {
+                resources = resolver.getResources(locationPattern);
+            } catch (IOException e) {
+                resources = null;
+                e.printStackTrace();
+            }
+            return convertToCucumberIterator(resources);
+        } else {
+            return fs.resources(path, suffix);
+        }
+    }
+    private Iterable<Resource> convertToCucumberIterator(org.springframework.core.io.Resource[] resources) {
+        List<Resource> results = new ArrayList<Resource>();
+        for (org.springframework.core.io.Resource resource : resources) {
+            results.add(new ResourceAdapter(resource));
+        }
+        return results;
+    }
+
+    public static String packageName(String gluePath) {
+        if (isClasspathPath(gluePath)) {
+            gluePath = stripClasspathPrefix(gluePath);
+        }
+        return gluePath.replace('/', '.').replace('\\', '.');
+    }
+
+    private static boolean isClasspathPath(String path) {
+        if (path.startsWith(CLASSPATH_SCHEME_TO_REPLACE)) {
+            path = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME);
+        }
+        return path.startsWith(CLASSPATH_SCHEME);
+    }
+
+    private static String stripClasspathPrefix(String path) {
+        if (path.startsWith(CLASSPATH_SCHEME_TO_REPLACE)) {
+            path = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME);
+        }
+        return path.substring(CLASSPATH_SCHEME.length());
+    }
+
+}
+

--- a/src/main/java/cucumber/runtime/io/CustomMultiLoader.java
+++ b/src/main/java/cucumber/runtime/io/CustomMultiLoader.java
@@ -1,62 +1,66 @@
 package cucumber.runtime.io;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
 public class CustomMultiLoader implements ResourceLoader {
-    public static final String CLASSPATH_SCHEME = "classpath*:";
-    public static final String CLASSPATH_SCHEME_TO_REPLACE = "classpath:";
-    private final ClasspathResourceLoader classpath;
-    private final FileResourceLoader fs;
-    public CustomMultiLoader(ClassLoader classLoader) {
-        classpath = new ClasspathResourceLoader(classLoader);
-        fs = new FileResourceLoader();
-    }
-    @Override
-    public Iterable<Resource> resources(String path, String suffix) {
-        if (isClasspathPath(path)) {
-            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-            String locationPattern = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME) + "/**/*" + suffix;
-            org.springframework.core.io.Resource[] resources;
-            try {
-                resources = resolver.getResources(locationPattern);
-            } catch (IOException e) {
-                resources = null;
-                e.printStackTrace();
-            }
-            return convertToCucumberIterator(resources);
-        } else {
-            return fs.resources(path, suffix);
-        }
-    }
-    private Iterable<Resource> convertToCucumberIterator(org.springframework.core.io.Resource[] resources) {
-        List<Resource> results = new ArrayList<Resource>();
-        for (org.springframework.core.io.Resource resource : resources) {
-            results.add(new ResourceAdapter(resource));
-        }
-        return results;
-    }
+	public static final String CLASSPATH_SCHEME = "classpath*:";
+	public static final String CLASSPATH_SCHEME_TO_REPLACE = "classpath:";
+	private final ClasspathResourceLoader classpath;
+	private final FileResourceLoader fs;
 
-    public static String packageName(String gluePath) {
-        if (isClasspathPath(gluePath)) {
-            gluePath = stripClasspathPrefix(gluePath);
-        }
-        return gluePath.replace('/', '.').replace('\\', '.');
-    }
+	public CustomMultiLoader(ClassLoader classLoader) {
+		classpath = new ClasspathResourceLoader(classLoader);
+		fs = new FileResourceLoader();
+	}
 
-    private static boolean isClasspathPath(String path) {
-        if (path.startsWith(CLASSPATH_SCHEME_TO_REPLACE)) {
-            path = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME);
-        }
-        return path.startsWith(CLASSPATH_SCHEME);
-    }
+	@Override
+	public Iterable<Resource> resources(String path, String suffix) {
+		if (isClasspathPath(path)) {
+			PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+			String locationPattern = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME) + "/**/*" + suffix;
+			org.springframework.core.io.Resource[] resources;
+			try {
+				resources = resolver.getResources(locationPattern);
+			} catch (IOException e) {
+				resources = null;
+				e.printStackTrace();
+			}
+			return convertToCucumberIterator(resources);
+		} else {
+			return fs.resources(path, suffix);
+		}
+	}
 
-    private static String stripClasspathPrefix(String path) {
-        if (path.startsWith(CLASSPATH_SCHEME_TO_REPLACE)) {
-            path = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME);
-        }
-        return path.substring(CLASSPATH_SCHEME.length());
-    }
+	private Iterable<Resource> convertToCucumberIterator(org.springframework.core.io.Resource[] resources) {
+		List<Resource> results = new ArrayList<Resource>();
+		for (org.springframework.core.io.Resource resource : resources) {
+			results.add(new ResourceAdapter(resource));
+		}
+		return results;
+	}
+
+	public static String packageName(String gluePath) {
+		if (isClasspathPath(gluePath)) {
+			gluePath = stripClasspathPrefix(gluePath);
+		}
+		return gluePath.replace('/', '.').replace('\\', '.');
+	}
+
+	private static boolean isClasspathPath(String path) {
+		if (path.startsWith(CLASSPATH_SCHEME_TO_REPLACE)) {
+			path = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME);
+		}
+		return path.startsWith(CLASSPATH_SCHEME);
+	}
+
+	private static String stripClasspathPrefix(String path) {
+		if (path.startsWith(CLASSPATH_SCHEME_TO_REPLACE)) {
+			path = path.replace(CLASSPATH_SCHEME_TO_REPLACE, CLASSPATH_SCHEME);
+		}
+		return path.substring(CLASSPATH_SCHEME.length());
+	}
 
 }
-

--- a/src/main/java/cucumber/runtime/io/ResourceAdapter.java
+++ b/src/main/java/cucumber/runtime/io/ResourceAdapter.java
@@ -1,0 +1,50 @@
+package cucumber.runtime.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ResourceAdapter implements Resource {
+    org.springframework.core.io.Resource springResource;
+
+    public ResourceAdapter(org.springframework.core.io.Resource springResource) {
+        this.springResource = springResource;
+    }
+
+    public String getPath() {
+        try {
+            return springResource.getFile().getPath();
+        } catch (IOException e) {
+            try {
+                return springResource.getURL().toString();
+            } catch (IOException e1) {
+                e1.printStackTrace();
+                return "";
+            }
+        }
+    }
+
+    public String getAbsolutePath() {
+        try {
+            return springResource.getFile().getAbsolutePath();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return this.springResource.getInputStream();
+    }
+
+    public String getClassName(String extension) {
+
+        String path = this.getPath();
+        if (path.startsWith("jar:")) {
+            path = path.substring(path.lastIndexOf("!") + 2);
+            return path.substring(0, path.length() - extension.length()).replace('/', '.');
+        } else {
+            path = path.substring(path.lastIndexOf("classes") + 8);
+            return path.substring(0, path.length() - extension.length()).replace('\\', '.');
+        }
+
+    }
+}

--- a/src/main/java/cucumber/runtime/io/ResourceAdapter.java
+++ b/src/main/java/cucumber/runtime/io/ResourceAdapter.java
@@ -3,48 +3,52 @@ package cucumber.runtime.io;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ResourceAdapter implements Resource {
-    org.springframework.core.io.Resource springResource;
+	org.springframework.core.io.Resource springResource;
+	private static final Logger LOG = LoggerFactory.getLogger(ResourceAdapter.class);
 
-    public ResourceAdapter(org.springframework.core.io.Resource springResource) {
-        this.springResource = springResource;
-    }
+	public ResourceAdapter(org.springframework.core.io.Resource springResource) {
+		this.springResource = springResource;
+	}
 
-    public String getPath() {
-        try {
-            return springResource.getFile().getPath();
-        } catch (IOException e) {
-            try {
-                return springResource.getURL().toString();
-            } catch (IOException e1) {
-                e1.printStackTrace();
-                return "";
-            }
-        }
-    }
+	public String getPath() {
+		try {
+			return springResource.getFile().getPath();
+		} catch (IOException e) {
+			try {
+				return springResource.getURL().toString();
+			} catch (IOException e1) {
+				LOG.error("Ошибка работы с файлом: " + e1);
+				return "";
+			}
+		}
+	}
 
-    public String getAbsolutePath() {
-        try {
-            return springResource.getFile().getAbsolutePath();
-        } catch (IOException e) {
-            return null;
-        }
-    }
+	public String getAbsolutePath() {
+		try {
+			return springResource.getFile().getAbsolutePath();
+		} catch (IOException e) {
+			return null;
+		}
+	}
 
-    public InputStream getInputStream() throws IOException {
-        return this.springResource.getInputStream();
-    }
+	public InputStream getInputStream() throws IOException {
+		return this.springResource.getInputStream();
+	}
 
-    public String getClassName(String extension) {
+	public String getClassName(String extension) {
 
-        String path = this.getPath();
-        if (path.startsWith("jar:")) {
-            path = path.substring(path.lastIndexOf("!") + 2);
-            return path.substring(0, path.length() - extension.length()).replace('/', '.');
-        } else {
-            path = path.substring(path.lastIndexOf("classes") + 8);
-            return path.substring(0, path.length() - extension.length()).replace('\\', '.');
-        }
+		String path = this.getPath();
+		if (path.startsWith("jar:")) {
+			path = path.substring(path.lastIndexOf("!") + 2);
+			return path.substring(0, path.length() - extension.length()).replace('/', '.');
+		} else {
+			path = path.substring(path.lastIndexOf("classes") + 8);
+			return path.substring(0, path.length() - extension.length()).replace('\\', '.');
+		}
 
-    }
+	}
 }

--- a/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
@@ -42,7 +42,6 @@ import ru.sbtqa.tag.datajack.Stash;
 import ru.sbtqa.tag.parsers.core.ParserItem;
 import ru.sbtqa.tag.qautils.properties.Props;
 import ru.sbtqa.tag.qautils.reflect.FieldUtilsExt;
-import com.jayway.jsonpath.PathNotFoundException;
 /**
  * Api object (ala Page object). Request to definite url with a set of
  * parameters such as request method, parameters, response validation.
@@ -554,7 +553,7 @@ public abstract class ApiEntry {
 						} catch (InstantiationException | IllegalAccessException | NoSuchMethodException
 								| SecurityException | InvocationTargetException ex) {
 							throw new ApiEntryInitializationException("Could not initialize parser callback", ex);
-						} catch (NoSuchElementException|PathNotFoundException e) {
+						} catch (Exception e) {
 							LOG.debug("No such element in callback", e);
 							if (field.getAnnotation(DependentResponseParam.class).necessity()) {
 								throw new NoSuchElementException(e.getMessage());

--- a/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
@@ -1,6 +1,10 @@
 package ru.sbtqa.tag.apifactory;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -14,10 +18,20 @@ import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ru.sbtqa.tag.apifactory.annotation.*;
+
+import ru.sbtqa.tag.apifactory.annotation.AddBracket;
+import ru.sbtqa.tag.apifactory.annotation.ApiAction;
+import ru.sbtqa.tag.apifactory.annotation.ApiActions;
+import ru.sbtqa.tag.apifactory.annotation.ApiRequestHeader;
+import ru.sbtqa.tag.apifactory.annotation.ApiRequestParam;
+import ru.sbtqa.tag.apifactory.annotation.ApiUrlParam;
+import ru.sbtqa.tag.apifactory.annotation.ApiValidationRule;
+import ru.sbtqa.tag.apifactory.annotation.DependentResponseParam;
+import ru.sbtqa.tag.apifactory.annotation.PutInStash;
 import ru.sbtqa.tag.apifactory.exception.ApiEntryInitializationException;
 import ru.sbtqa.tag.apifactory.exception.ApiException;
 import ru.sbtqa.tag.apifactory.repositories.Bullet;
@@ -37,597 +51,665 @@ import ru.sbtqa.tag.qautils.reflect.FieldUtilsExt;
  */
 public abstract class ApiEntry {
 
-    protected static final Logger LOG = LoggerFactory.getLogger(ApiEntry.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ApiEntry.class);
 
-    private String requestPath = this.getClass().getAnnotation(ApiAction.class).path();
-    private final Map<String, String> headers = new HashMap<>();
-    private final Map<String, Object> parameters = new HashMap<>();
-    private String body = null;
-    private String template = this.getClass().getAnnotation(ApiAction.class).template();
+	private String requestPath;
+	private final Map<String, String> headers = new HashMap<>();
+	private final Map<String, Object> parameters = new HashMap<>();
+	private String body = null;
+	private String template;
+	private String title;
+	private HTTP requestMethod;
 
-    /**
-     * Set request parameter by title
-     *
-     * @param title a {@link java.lang.String} object.
-     * @param value a {@link java.lang.String} object.
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if
-     */
-    public void setParamValueByTitle(String title, String value) throws ApiException {
-        List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
-        for (Field field : fieldList) {
-            for (Annotation annotation : field.getAnnotations()) {
-                if (((annotation instanceof ApiRequestParam && ((ApiRequestParam) annotation).title().equals(title))
-                        || (annotation instanceof ApiUrlParam && ((ApiUrlParam) annotation).title().equals(title)))
-                        && value != null && !value.isEmpty()) {
-                    field.setAccessible(true);
-                    try {
-                        field.set(this, value);
-                    } catch (IllegalArgumentException | IllegalAccessException ex) {
-                        throw new ApiEntryInitializationException("Parameter with title '" + title + "' is not available", ex);
-                    }
-                    return;
-                }
-            }
+	protected void toApiEntry(String title) {
+		this.title = title;
+		for (Annotation annotation : this.getClass().getAnnotations()) {
+			if (annotation instanceof ApiAction && ((ApiAction) annotation).title().equals(title)) {
+				requestPath = ((ApiAction) annotation).path();
+				template = ((ApiAction) annotation).template();
+				requestMethod = ((ApiAction) annotation).method();
+				break;
+			} else if (annotation instanceof ApiActions) {
+				for (ApiAction apiAction : ((ApiActions) annotation).value()) {
+					if (apiAction.title().equals(title)) {
+						requestPath = apiAction.path();
+						template = apiAction.template();
+						requestMethod = apiAction.method();
+					}
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Set request parameter by title
+	 *
+	 * @param title
+	 *            a {@link java.lang.String} object.
+	 * @param value
+	 *            a {@link java.lang.String} object.
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if
+	 */
+	public void setParamValueByTitle(String title, String value) throws ApiException {
+		List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
+		for (Field field : fieldList) {
+			for (Annotation annotation : field.getAnnotations()) {
+				if (((annotation instanceof ApiRequestParam && ((ApiRequestParam) annotation).title().equals(title))
+						|| (annotation instanceof ApiUrlParam && ((ApiUrlParam) annotation).title().equals(title)))
+						&& value != null && !value.isEmpty()) {
+					field.setAccessible(true);
+					try {
+						field.set(this, value);
+					} catch (IllegalArgumentException | IllegalAccessException ex) {
+						throw new ApiEntryInitializationException(
+								"Parameter with title '" + title + "' is not available", ex);
+					}
+					return;
+				}
+			}
+		}
+		throw new ApiEntryInitializationException(
+				"There is no '" + title + "' parameter in '" + this.getActionTitle() + "' api entry.");
+	}
+
+	/**
+	 * Set request parameter by name
+	 *
+	 * @param name
+	 *            a {@link java.lang.String} object.
+	 * @param value
+	 *            a {@link java.lang.String} object.
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if parameter with name doesn't exists or not available
+	 */
+	protected void setParamValueByName(String name, Object value) throws ApiException {
+		List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
+		for (Field field : fieldList) {
+			if (name.equals(field.getName())) {
+				field.setAccessible(true);
+				try {
+					field.set(this, value);
+				} catch (IllegalArgumentException | IllegalAccessException ex) {
+					throw new ApiEntryInitializationException("Failed to write value to field '" + name + "'", ex);
+				}
+				return;
+			}
+		}
+		throw new ApiEntryInitializationException(
+				"There is no parameter with name '" + name + "' in '" + this.getActionTitle() + "' api entry.");
+	}
+
+	/**
+	 * Fill request parameters from data table
+	 *
+	 * @param params
+	 *            the list of parameters
+	 */
+	public void fillParams(Map<String, String> params) {
+
+		for (Map.Entry<String, String> p : params.entrySet()) {
+			try {
+				setParamValueByTitle(p.getKey(), p.getValue());
+			} catch (ApiException e) {
+				LOG.error("Failed to set params value by title", e);
+			}
+		}
+	}
+
+	/**
+	 * Fill api request parameters, api request headers, request body and
+	 * replace templates in requestPath
+	 *
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if there is an error in setters method
+	 */
+	public void fillParameters() throws ApiException {
+		applyParametersAnnotation();
+		setHeaders();
+		setBody();
+
+		// if api action path contains parameters like '%parameter' replace it
+		// with it value
+		for (Map.Entry<String, Object> parameter : sortByKeyLength(parameters).entrySet()) {
+			if (parameter.getValue() instanceof String) {
+				requestPath = requestPath.replaceAll("%" + parameter.getKey(), (String) parameter.getValue());
+			} else {
+				LOG.debug("Failed to substitute not String field to path template");
+			}
+		}
+	}
+
+	/**
+	 * Override it if you want to do pre-fire actions such as database run-up,
+	 * test data prepare or something else
+	 *
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if there is an error in user's prepare steps
+	 */
+	public void prepare() throws ApiException {
+
+	}
+
+	/**
+	 * Perform action with request method to url. Override it if you need use
+	 * another rest or soap implementation
+	 *
+	 * @param url
+	 *            action target
+	 * @return response
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if response is not an instance of bullet type
+	 */
+	public Object fire(String url) throws ApiException {
+		// Get request method of current api object
+		HTTP requestMethod = getActionMethod();
+		String templateName = getTemplate();
+
+		url = getFullUrl(url);
+
+		Bullet response = null;
+		Bullet request = null;
+		Class restImpl = ApiFactory.getApiFactory().getRest();
+		Class soapImpl = ApiFactory.getApiFactory().getSoap();
+		try {
+			Rest rest = (Rest) restImpl.newInstance();
+			Soap soap = (Soap) soapImpl.newInstance();
+
+			Object bd;
+			if (!"".equals(templateName)) {
+				bd = getBody();
+			} else {
+				bd = getParameters();
+			}
+
+			Map<String, String> hdrs = getHeaders();
+			switch (requestMethod) {
+			case GET:
+				response = (Bullet) rest.get(url, hdrs);
+				ApiFactory.getApiFactory().addRequestHeadersToRepository(this.getClass(), hdrs);
+				break;
+			case POST:
+				response = (Bullet) rest.post(url, hdrs, bd);
+				request = new Bullet(hdrs, bd.toString());
+				ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
+				break;
+			case PUT:
+				response = (Bullet) rest.put(url, hdrs, bd);
+				request = new Bullet(hdrs, bd.toString());
+				ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
+				break;
+			case PATCH:
+				response = (Bullet) rest.patch(url, hdrs, bd);
+				request = new Bullet(hdrs, bd.toString());
+				ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
+				break;
+			case DELETE:
+				response = (Bullet) rest.delete(url, hdrs);
+				ApiFactory.getApiFactory().addRequestHeadersToRepository(this.getClass(), hdrs);
+				break;
+			case SOAP:
+				response = (Bullet) soap.send(url, hdrs, bd, Proxy.NO_PROXY);
+				request = new Bullet(hdrs, bd.toString());
+				ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
+				break;
+			default:
+				throw new UnsupportedOperationException("Request method " + requestMethod + " is not support");
+			}
+		} catch (InstantiationException | IllegalAccessException ex) {
+			LOG.error("Error with fire method implementation generate", ex);
+		}
+
+		return response;
+	}
+
+	/**
+	 * Perform api request. Consist of prepare step, fill parameters step, build
+	 * url and fire request step
+	 *
+	 * @return response
+	 * @throws ApiException
+	 *             if there is an error in setters, prepare or fire methods
+	 */
+	public Object fireRequest() throws ApiException {
+		setDependentResponseParameters();
+		prepare();
+		fillParameters();
+
+		String requestUrl = ApiFactory.getApiRequestUrl();
+		String url = requestUrl + "/" + requestPath;
+
+		Object response = fire(url);
+		// Put response to response repository
+		ApiFactory.getApiFactory().addResponseToRepository(this.getClass(), (Bullet) response);
+		return response;
+	}
+
+	/**
+	 * Perform api request. Consist of prepare step, fill parameters step, build
+	 * url and fire request step
+	 *
+	 * @param url
+	 *            target url to fire
+	 * @return response
+	 * @throws ApiException
+	 *             if there is an error in setters, prepare or fire methods
+	 */
+	public Object fireRequest(String url) throws ApiException {
+		setDependentResponseParameters();
+		prepare();
+		fillParameters();
+
+		Object response = fire(url);
+		// Put response to response repository
+		ApiFactory.getApiFactory().addResponseToRepository(this.getClass(), (Bullet) response);
+		return response;
+	}
+
+	/**
+	 * Perform action validation rule
+	 *
+	 * @param title
+	 *            a {@link java.lang.String} object.
+	 * @param params
+	 *            a {@link java.lang.Object} object.
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if can't invoke method
+	 */
+	public void fireValidationRule(String title, Object... params) throws ApiException {
+		Method[] methods = this.getClass().getMethods();
+		for (Method method : methods) {
+			if (null != method.getAnnotation(ApiValidationRule.class)
+					&& method.getAnnotation(ApiValidationRule.class).title().equals(title)) {
+				try {
+					method.invoke(this, params);
+				} catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
+					throw new ApiException("Failed to invoke method", e);
+				}
+				return;
+			}
+		}
+		throw new ApiEntryInitializationException(
+				"There is no '" + title + "' validation rule in '" + this.getActionTitle() + "' api entry.");
+	}
+
+	/**
+	 * Get parameters annotated by ApiRequestParam. Fill it by another response
+	 * if annotated by DependentResponseParam, put value in stash and add
+	 * brackets by the way.
+	 *
+	 * @throws ApiException
+	 *             if one of parameters is not available
+	 */
+	public void applyParametersAnnotation() throws ApiException {
+		// for each field in api request object search for annotations
+		List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
+		for (Field field : fieldList) {
+			field.setAccessible(true);
+
+			String name = null;
+			Object value = null;
+
+			// @ApiRequestParam. Get field name and value
+			if (null != field.getAnnotation(ApiRequestParam.class)) {
+				name = field.getName();
+				try {
+					value = field.get(this);
+				} catch (IllegalArgumentException | IllegalAccessException ex) {
+					throw new ApiEntryInitializationException("Parameter with name '" + name + "' is not available",
+							ex);
+				}
+			}
+
+			// @PutInStash. Put name (or title) and value to stash
+			if (null != field.getAnnotation(PutInStash.class)) {
+				PutInStash putInStashAnnotation = field.getAnnotation(PutInStash.class);
+				switch (putInStashAnnotation.by()) {
+				case NAME:
+					try {
+						Stash.asMap().put(field.getName(), (String) field.get(this));
+					} catch (IllegalArgumentException | IllegalAccessException ex) {
+						throw new ApiEntryInitializationException("Parameter with name '" + name + "' is not available",
+								ex);
+					}
+					break;
+				case TITLE:
+					if (null != field.getAnnotation(ApiRequestParam.class)) {
+						Stash.asMap().put(field.getAnnotation(ApiRequestParam.class).title(), value);
+					} else {
+						LOG.error("The field annotated by @PutInStash does not annotated by @ApiRequestParam");
+					}
+					break;
+				}
+			}
+
+			// set parameter value by name only if it has one of parameter's
+			// annotation
+			if (null != name) {
+				setParamValueByName(name, value);
+
+				// @AddBracket. Get name from value. Use it if value need to
+				// contains brackets.
+				if (null != field.getAnnotation(AddBracket.class)) {
+					name = field.getAnnotation(AddBracket.class).value();
+				}
+				parameters.put(name, value);
+			}
+		}
+	}
+
+	/**
+	 * Get and fill api entry headers
+	 *
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if one of headers is not available
+	 */
+	protected void setHeaders() throws ApiException {
+		List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
+		for (Field field : fieldList) {
+			for (Annotation annotation : field.getAnnotations()) {
+				if (annotation instanceof ApiRequestHeader) {
+					field.setAccessible(true);
+					try {
+						headers.put(((ApiRequestHeader) annotation).header(), (String) field.get(this));
+					} catch (IllegalArgumentException | IllegalAccessException ex) {
+						throw new ApiEntryInitializationException("Parameter with headers title '"
+								+ ((ApiRequestHeader) annotation).header() + "' is not available", ex);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get url with param if param field exist
+	 *
+	 * @return partUrl withParams
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 */
+	protected String getFullUrl(String url) throws ApiException {
+		List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
+		String urlParamString = "";
+		for (Field field : fieldList) {
+			ApiUrlParam urlParam = field.getAnnotation(ApiUrlParam.class);
+			if (urlParam != null && !"".equals(urlParam.title())) {
+				field.setAccessible(true);
+				try {
+					String param = (String) field.get(this);
+					if (param != null && !param.equals("")) {
+						if (!"".equals(urlParamString)) {
+							urlParamString += "&";
+						}
+						urlParamString += urlParam.title() + "=" + param;
+					}
+				} catch (IllegalArgumentException | IllegalAccessException ex) {
+					throw new ApiEntryInitializationException(
+							"Parameter with title '" + urlParam.title() + "' is not available", ex);
+				}
+			}
+		}
+
+		if (!urlParamString.equals("")) {
+			if (url.contains("?")) {
+				url += "&" + urlParamString;
+			} else {
+				url += "?" + urlParamString;
+			}
+		}
+		return url;
+	}
+
+	/**
+	 * Get request body. Get request body template from resources
+	 *
+	 * @throws ru.sbtqa.tag.apifactory.exception.ApiException
+	 *             if template file doesn't exist or not available
+	 */
+	public void setBody() throws ApiException {
+		if (!"".equals(template)) {
+			// get body template from resources
+			String templatePath = Props.get("api.template.path", "");
+			String encoding = Props.get("api.encoding");
+			String templateFullPath = templatePath + template;
+			try {
+				body = IOUtils.toString(inputStreamFile(templateFullPath), encoding).replace("\uFEFF", "");
+			} catch (NullPointerException ex) {
+				throw new ApiEntryInitializationException("Can't find template file by path " + templateFullPath, ex);
+			} catch (IOException ex) {
+				throw new ApiEntryInitializationException("Template file '" + templateFullPath + "' is not available",
+						ex);
+			}
+
+			// replace %parameter on parameter value
+			for (Map.Entry<String, Object> parameter : parameters.entrySet()) {
+				if (parameter.getValue() instanceof String) {
+					String value = (null != parameter.getValue()) ? (String) parameter.getValue() : "";
+					body = body.replaceAll("%" + parameter.getKey(), value);
+				} else if (parameter.getValue() instanceof List) {
+					String value = "";
+					String separator = Props.get("api.dependent.array.separator");
+					List<String> params = ((List) parameter.getValue());
+					for (int i = 0; i < params.size(); i++) {
+						value += params.get(i);
+						if (separator != null && i != params.size() - 1) {
+							value += separator;
+						}
+					}
+
+					body = body.replaceAll("%" + parameter.getKey(), value);
+				} else {
+					LOG.debug("Failed to substitute not String field to body template");
+				}
+			}
+		}
+	}
+
+	public InputStream inputStreamFile(String templateFullPath) throws FileNotFoundException {
+		InputStream is = getClass().getClassLoader().getResourceAsStream(templateFullPath);
+		if (is == null) {
+			is = new FileInputStream(new File(templateFullPath));
+		}
+		return is;
+	}
+
+	@SuppressWarnings("ThrowableResultIgnored")
+	protected void setDependentResponseParameters() throws ApiException {
+		List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
+		for (Field field : fieldList) {
+			field.setAccessible(true);
+
+			// @DependentResponseParam. Go to response in responseEntry and get
+			// some value by path
+			if (null != field.getAnnotation(DependentResponseParam.class)) {
+				DependentResponseParam dependantParamAnnotation = field.getAnnotation(DependentResponseParam.class);
+				Object fieldValue = null;
+				Class responseEntry = dependantParamAnnotation.responseEntry();
+
+				if ((responseEntry == void.class || responseEntry == null)
+						&& dependantParamAnnotation.usePreviousResponse()) {
+					responseEntry = ApiFactory.getApiFactory().getResponseRepository().getLastEntryInRepository();
+				}
+
+				if (!"".equals(dependantParamAnnotation.header())) {
+					Map<String, String> dependantResponseHeaders = ApiFactory.getApiFactory().getResponseRepository()
+							.getHeaders(responseEntry);
+					for (Map.Entry<String, String> header : dependantResponseHeaders.entrySet()) {
+						if (null != header.getKey() && header.getKey().equals(dependantParamAnnotation.header())) {
+							fieldValue = header.getValue();
+						}
+					}
+				} else {
+					Object dependantResponseBody = ApiFactory.getApiFactory().getResponseRepository()
+							.getBody(responseEntry);
+
+					// Use applied parser to get value by path throw the
+					// callback
+					if (ApiFactory.getApiFactory().getParser() != null) {
+						Object callbackResult = null;
+						try {
+							ParserItem item = new ParserItem((String) dependantResponseBody,
+									dependantParamAnnotation.path());
+							callbackResult = ApiFactory.getApiFactory().getParser().getConstructor().newInstance()
+									.call(item);
+						} catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+								| SecurityException | InvocationTargetException ex) {
+							throw new ApiEntryInitializationException("Could not initialize parser callback", ex);
+						} catch (NoSuchElementException e) {
+							LOG.debug("No such element in callback", e);
+							if (field.getAnnotation(DependentResponseParam.class).necessity()) {
+								throw new NoSuchElementException(e.getMessage());
+							}
+						}
+						if (callbackResult instanceof Exception) {
+							throw (ApiException) callbackResult;
+						} else {
+							fieldValue = callbackResult;
+						}
+					} else {
+						throw new ApiEntryInitializationException("Could not initialize parser callback");
+					}
+				}
+
+				if (!"".equals(dependantParamAnnotation.mask())) {
+					if (fieldValue instanceof String) {
+						Matcher matcher = Pattern.compile(dependantParamAnnotation.mask()).matcher((String) fieldValue);
+						fieldValue = "";
+						if (matcher.find()) {
+							fieldValue = matcher.group(1);
+						}
+					} else {
+						throw new ApiException(
+								"Masking was failed because " + field.getName() + " is not instance of String");
+					}
+				}
+
+				parameters.put(field.getName(), fieldValue);
+				setParamValueByName(field.getName(), fieldValue);
+			}
+		}
+	}
+
+	protected Map<String, Object> sortByKeyLength(Map<String, Object> map) {
+		Map<String, Object> treeMap = new TreeMap<>(new Comparator<String>() {
+			@Override
+			public int compare(String s1, String s2) {
+				if (s1.length() > s2.length()) {
+					return -1;
+				} else if (s1.length() < s2.length()) {
+					return 1;
+				} else {
+					return s1.compareTo(s2);
+				}
+			}
+		});
+
+		treeMap.putAll(map);
+		return treeMap;
+	}
+
+	/**
+	 * Get headers
+	 *
+	 * @return the headers
+	 */
+	public Map<String, String> getHeaders() {
+		return headers;
+	}
+
+	/**
+	 * Add header to headers map
+	 * 
+	 * @param key
+	 * @param value
+	 */
+	public void addHeader(String key, String value) {
+		headers.put(key, value);
+	}
+
+	/**
+	 * Get parameters
+	 *
+	 * @return the parameters
+	 */
+	public Map<String, Object> getParameters() {
+		return parameters;
+	}
+
+	/**
+	 * Add parameter to parameters map
+	 * 
+	 * @param key
+	 * @param value
+	 */
+	public void addParameter(String key, Object value) {
+		parameters.put(key, value);
+	}
+
+	/**
+	 * Get request body
+	 *
+	 * @return the body
+	 */
+	public String getBody() {
+		return body;
+	}
+
+	/**
+	 * Set request body
+	 *
+	 * @param body
+	 *            a {@link java.lang.String} object.
+	 */
+	public void setBody(String body) {
+		this.body = body;
+	}
+
+	/**
+	 * Get template name
+	 *
+	 * @return the template
+	 */
+	public String getTemplate() {
+		return template;
+	}
+
+	/**
+	 * Set template name
+	 *
+	 * @param template
+	 *            the template to set
+	 */
+	public void setTemplate(String template) {
+		this.template = template;
+	}
+
+	/**
+	 * Get api action path
+	 *
+	 * @return action path
+	 */
+	public String getActionPath() {
+		return requestPath;
+
+	}
+        /**
+        * Set action path
+        * @param path
+        */
+        public void setActionPath(String path) {
+            requestPath = path;
         }
-        throw new ApiEntryInitializationException("There is no '" + title + "' parameter in '" + this.getActionTitle() + "' api entry.");
-    }
+	/**
+	 * Get api action title
+	 *
+	 * @return title
+	 */
+	public String getActionTitle() {
+		return this.title;
+	}
 
-    /**
-     * Set request parameter by name
-     *
-     * @param name a {@link java.lang.String} object.
-     * @param value a {@link java.lang.String} object.
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if parameter with
-     * name doesn't exists or not available
-     */
-    protected void setParamValueByName(String name, Object value) throws ApiException {
-        List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
-        for (Field field : fieldList) {
-            if (name.equals(field.getName())) {
-                field.setAccessible(true);
-                try {
-                    field.set(this, value);
-                } catch (IllegalArgumentException | IllegalAccessException ex) {
-                    throw new ApiEntryInitializationException("Failed to write value to field '" + name + "'", ex);
-                }
-                return;
-            }
-        }
-        throw new ApiEntryInitializationException("There is no parameter with name '" + name + "' in '" + this.getActionTitle() + "' api entry.");
-    }
-
-    /**
-     * Fill request parameters from data table
-     *
-     * @param params the list of parameters
-     */
-    public void fillParams(Map<String, String> params) {
-
-        for (Map.Entry<String, String> p : params.entrySet()) {
-            try {
-                setParamValueByTitle(p.getKey(), p.getValue());
-            } catch (ApiException e) {
-                LOG.error("Failed to set params value by title", e);
-            }
-        }
-    }
-
-    /**
-     * Fill api request parameters, api request headers, request body and
-     * replace templates in requestPath
-     *
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if there is an
-     * error in setters method
-     */
-    public void fillParameters() throws ApiException {
-        applyParametersAnnotation();
-        setHeaders();
-        setBody();
-
-        //if api action path contains parameters like '%parameter' replace it with it value
-        for (Map.Entry<String, Object> parameter : sortByKeyLength(parameters).entrySet()) {
-            if (parameter.getValue() instanceof String) {
-                requestPath = requestPath.replaceAll("%" + parameter.getKey(), (String) parameter.getValue());
-            } else {
-                LOG.debug("Failed to substitute not String field to path template");
-            }
-        }
-    }
-
-    /**
-     * Override it if you want to do pre-fire actions such as database run-up,
-     * test data prepare or something else
-     *
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if there is an
-     * error in user's prepare steps
-     */
-    public void prepare() throws ApiException {
-
-    }
-
-    /**
-     * Perform action with request method to url. Override it if you need use
-     * another rest or soap implementation
-     *
-     * @param url action target
-     * @return response
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if response is not
-     * an instance of bullet type
-     */
-    public Object fire(String url) throws ApiException {
-        //Get request method of current api object
-        HTTP requestMethod = this.getClass().getAnnotation(ApiAction.class).method();
-        String templateName = this.getClass().getAnnotation(ApiAction.class).template();
-
-        url = getFullUrl(url);
-
-        Bullet response = null;
-        Bullet request = null;
-        Class restImpl = ApiFactory.getApiFactory().getRest();
-        Class soapImpl = ApiFactory.getApiFactory().getSoap();
-        try {
-            Rest rest = (Rest) restImpl.newInstance();
-            Soap soap = (Soap) soapImpl.newInstance();
-
-            Object bd;
-            if (!"".equals(templateName)) {
-                bd = getBody();
-            } else {
-                bd = getParameters();
-            }
-
-            Map<String, String> hdrs = getHeaders();
-            switch (requestMethod) {
-                case GET:
-                    response = (Bullet) rest.get(url, hdrs);
-                    ApiFactory.getApiFactory().addRequestHeadersToRepository(this.getClass(), hdrs);
-                    break;
-                case POST:
-                    response = (Bullet) rest.post(url, hdrs, bd);
-                    request = new Bullet(hdrs, bd.toString());
-                    ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
-                    break;
-                case PUT:
-                    response = (Bullet) rest.put(url, hdrs, bd);
-                    request = new Bullet(hdrs, bd.toString());
-                    ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
-                    break;
-                case PATCH:
-                    response = (Bullet) rest.patch(url, hdrs, bd);
-                    request = new Bullet(hdrs, bd.toString());
-                    ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
-                    break;
-                case DELETE:
-                    response = (Bullet) rest.delete(url, hdrs);
-                    ApiFactory.getApiFactory().addRequestHeadersToRepository(this.getClass(), hdrs);
-                    break;
-                case SOAP:
-                    response = (Bullet) soap.send(url, hdrs, bd, Proxy.NO_PROXY);
-                    request = new Bullet(hdrs, bd.toString());
-                    ApiFactory.getApiFactory().addRequestToRepository(this.getClass(), request);
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Request method " + requestMethod + " is not support");
-            }
-        } catch (InstantiationException | IllegalAccessException ex) {
-            LOG.error("Error with fire method implementation generate", ex);
-        }
-
-        return response;
-    }
-
-    /**
-     * Perform api request. Consist of prepare step, fill parameters step, build
-     * url and fire request step
-     *
-     * @return response
-     * @throws ApiException if there is an error in setters, prepare or fire
-     * methods
-     */
-    public Object fireRequest() throws ApiException {
-        setDependentResponseParameters();
-        prepare();
-        fillParameters();
-
-        String requestUrl = ApiFactory.getApiRequestUrl();
-        String url = requestUrl + "/" + requestPath;
-
-        Object response = fire(url);
-        //Put response to response repository
-        ApiFactory.getApiFactory().addResponseToRepository(this.getClass(), (Bullet) response);
-        return response;
-    }
-
-    /**
-     * Perform api request. Consist of prepare step, fill parameters step, build
-     * url and fire request step
-     *
-     * @param url target url to fire
-     * @return response
-     * @throws ApiException if there is an error in setters, prepare or fire
-     * methods
-     */
-    public Object fireRequest(String url) throws ApiException {
-        setDependentResponseParameters();
-        prepare();
-        fillParameters();
-
-        Object response = fire(url);
-        //Put response to response repository
-        ApiFactory.getApiFactory().addResponseToRepository(this.getClass(), (Bullet) response);
-        return response;
-    }
-
-    /**
-     * Perform action validation rule
-     *
-     * @param title a {@link java.lang.String} object.
-     * @param params a {@link java.lang.Object} object.
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if can't invoke
-     * method
-     */
-    public void fireValidationRule(String title, Object... params) throws ApiException {
-        Method[] methods = this.getClass().getMethods();
-        for (Method method : methods) {
-            if (null != method.getAnnotation(ApiValidationRule.class)
-                    && method.getAnnotation(ApiValidationRule.class).title().equals(title)) {
-                try {
-                    method.invoke(this, params);
-                } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
-                    throw new ApiException("Failed to invoke method", e);
-                }
-                return;
-            }
-        }
-        throw new ApiEntryInitializationException("There is no '" + title + "' validation rule in '" + this.getActionTitle() + "' api entry.");
-    }
-
-    /**
-     * Get parameters annotated by ApiRequestParam. Fill it by another response
-     * if annotated by DependentResponseParam, put value in stash and add
-     * brackets by the way.
-     *
-     * @throws ApiException if one of parameters is not available
-     */
-    public void applyParametersAnnotation() throws ApiException {
-        //for each field in api request object search for annotations
-        List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
-        for (Field field : fieldList) {
-            field.setAccessible(true);
-
-            String name = null;
-            Object value = null;
-
-            //@ApiRequestParam. Get field name and value
-            if (null != field.getAnnotation(ApiRequestParam.class)) {
-                name = field.getName();
-                try {
-                    value = field.get(this);
-                } catch (IllegalArgumentException | IllegalAccessException ex) {
-                    throw new ApiEntryInitializationException("Parameter with name '" + name + "' is not available", ex);
-                }
-            }
-
-            //@PutInStash. Put name (or title) and value to stash
-            if (null != field.getAnnotation(PutInStash.class)) {
-                PutInStash putInStashAnnotation = field.getAnnotation(PutInStash.class);
-                switch (putInStashAnnotation.by()) {
-                    case NAME:
-                        try {
-                            Stash.asMap().put(field.getName(), (String) field.get(this));
-                        } catch (IllegalArgumentException | IllegalAccessException ex) {
-                            throw new ApiEntryInitializationException("Parameter with name '" + name + "' is not available", ex);
-                        }
-                        break;
-                    case TITLE:
-                        if (null != field.getAnnotation(ApiRequestParam.class)) {
-                            Stash.asMap().put(field.getAnnotation(ApiRequestParam.class).title(), value);
-                        } else {
-                            LOG.error("The field annotated by @PutInStash does not annotated by @ApiRequestParam");
-                        }
-                        break;
-                }
-            }
-
-            //set parameter value by name only if it has one of parameter's annotation
-            if (null != name) {
-                setParamValueByName(name, value);
-
-                //@AddBracket. Get name from value. Use it if value need to contains brackets.
-                if (null != field.getAnnotation(AddBracket.class)) {
-                    name = field.getAnnotation(AddBracket.class).value();
-                }
-                parameters.put(name, value);
-            }
-        }
-    }
-
-    /**
-     * Get and fill api entry headers
-     *
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if one of headers
-     * is not available
-     */
-    protected void setHeaders() throws ApiException {
-        List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
-        for (Field field : fieldList) {
-            for (Annotation annotation : field.getAnnotations()) {
-                if (annotation instanceof ApiRequestHeader) {
-                    field.setAccessible(true);
-                    try {
-                        headers.put(((ApiRequestHeader) annotation).header(), (String) field.get(this));
-                    } catch (IllegalArgumentException | IllegalAccessException ex) {
-                        throw new ApiEntryInitializationException("Parameter with headers title '" + ((ApiRequestHeader) annotation).header() + "' is not available", ex);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Get url with param if param field exist
-     *
-     * @return partUrl withParams
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException
-     */
-    protected String getFullUrl(String url) throws ApiException {
-        List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
-        String urlParamString = "";
-        for (Field field : fieldList) {
-            ApiUrlParam urlParam = field.getAnnotation(ApiUrlParam.class);
-            if (urlParam != null && !"".equals(urlParam.title())) {
-                field.setAccessible(true);
-                try {
-                    String param = (String) field.get(this);
-                    if (param != null && !param.equals("")) {
-                        if (!"".equals(urlParamString)) {
-                            urlParamString += "&";
-                        }
-                        urlParamString += urlParam.title() + "=" + param;
-                    }
-                } catch (IllegalArgumentException | IllegalAccessException ex) {
-                    throw new ApiEntryInitializationException("Parameter with title '" + urlParam.title()+ "' is not available", ex);
-                }
-            }
-        }
-
-        if (!urlParamString.equals("")) {
-            if (url.contains("?")) {
-                url += "&" + urlParamString;
-            } else {
-                url += "?" + urlParamString;
-            }
-        }
-        return url;
-    }
-
-    /**
-     * Get request body. Get request body template from resources
-     *
-     * @throws ru.sbtqa.tag.apifactory.exception.ApiException if template file
-     * doesn't exist or not available
-     */
-    public void setBody() throws ApiException {
-        if (!"".equals(template)) {
-            //get body template from resources
-            String templatePath = Props.get("api.template.path", "");
-            String encoding = Props.get("api.encoding");
-            String templateFullPath = templatePath + template;
-            try {
-                body = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(templateFullPath), encoding).replace("\uFEFF", "");
-            } catch (NullPointerException ex) {
-                throw new ApiEntryInitializationException("Can't find template file by path " + templateFullPath, ex);
-            } catch (IOException ex) {
-                throw new ApiEntryInitializationException("Template file '" + templateFullPath + "' is not available", ex);
-            }
-
-            //replace %parameter on parameter value
-            for (Map.Entry<String, Object> parameter : parameters.entrySet()) {
-                if (parameter.getValue() instanceof String) {
-                    String value = (null != parameter.getValue()) ? (String) parameter.getValue() : "";
-                    body = body.replaceAll("%" + parameter.getKey(), value);
-                } else if (parameter.getValue() instanceof List) {
-                    String value = "";
-                    String separator = Props.get("api.dependent.array.separator");
-                    List<String> params = ((List) parameter.getValue());
-                    for (int i = 0; i < params.size(); i++) {
-                        value += params.get(i);
-                        if (separator != null && i != params.size() - 1) {
-                            value += separator;
-                        }
-                    }
-
-                    body = body.replaceAll("%" + parameter.getKey(), value);
-                } else {
-                    LOG.debug("Failed to substitute not String field to body template");
-                }
-            }
-        }
-    }
-
-    @SuppressWarnings("ThrowableResultIgnored")
-    protected void setDependentResponseParameters() throws ApiException {
-        List<Field> fieldList = FieldUtilsExt.getDeclaredFieldsWithInheritance(this.getClass());
-        for (Field field : fieldList) {
-            field.setAccessible(true);
-
-            //@DependentResponseParam. Go to response in responseEntry and get some value by path
-            if (null != field.getAnnotation(DependentResponseParam.class)) {
-                DependentResponseParam dependantParamAnnotation = field.getAnnotation(DependentResponseParam.class);
-                Object fieldValue = null;
-                Class responseEntry = dependantParamAnnotation.responseEntry();
-
-                if ((responseEntry == void.class || responseEntry == null)
-                        && dependantParamAnnotation.usePreviousResponse()) {
-                    responseEntry = ApiFactory.getApiFactory().getResponseRepository().getLastEntryInRepository();
-                }
-
-                if (!"".equals(dependantParamAnnotation.header())) {
-                    Map<String, String> dependantResponseHeaders = ApiFactory.getApiFactory().getResponseRepository().getHeaders(responseEntry);
-                    for (Map.Entry<String, String> header : dependantResponseHeaders.entrySet()) {
-                        if (null != header.getKey() && header.getKey().equals(dependantParamAnnotation.header())) {
-                            fieldValue = header.getValue();
-                        }
-                    }
-                } else {
-                    Object dependantResponseBody = ApiFactory.getApiFactory().getResponseRepository().getBody(responseEntry);
-
-                    //Use applied parser to get value by path throw the callback
-                    if (ApiFactory.getApiFactory().getParser() != null) {
-                        Object callbackResult = null;
-                        try {
-                            ParserItem item = new ParserItem((String) dependantResponseBody, dependantParamAnnotation.path());
-                            callbackResult = ApiFactory.getApiFactory().getParser().getConstructor().newInstance().call(item);
-                        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
-                            throw new ApiEntryInitializationException("Could not initialize parser callback", ex);
-                        } catch (Exception e) {
-                            LOG.debug("No such element in callback", e);
-                            if (field.getAnnotation(DependentResponseParam.class).necessity()) {
-                                throw new NoSuchElementException(e.getMessage());
-                            }
-                        }
-                        if (callbackResult instanceof Exception) {
-                            throw (ApiException) callbackResult;
-                        } else {
-                            fieldValue = callbackResult;
-                        }
-                    } else {
-                        throw new ApiEntryInitializationException("Could not initialize parser callback");
-                    }
-                }
-
-                if (!"".equals(dependantParamAnnotation.mask())) {
-                    if (fieldValue instanceof String) {
-                        Matcher matcher = Pattern.compile(dependantParamAnnotation.mask()).matcher((String) fieldValue);
-                        fieldValue = "";
-                        if (matcher.find()) {
-                            fieldValue = matcher.group(1);
-                        }
-                    } else {
-                        throw new ApiException("Masking was failed because " + field.getName() + " is not instance of String");
-                    }
-                }
-
-                parameters.put(field.getName(), fieldValue);
-                setParamValueByName(field.getName(), fieldValue);
-            }
-        }
-    }
-
-    protected Map<String, Object> sortByKeyLength(Map<String, Object> map) {
-        Map<String, Object> treeMap = new TreeMap<>(
-                new Comparator<String>() {
-            @Override
-            public int compare(String s1, String s2) {
-                if (s1.length() > s2.length()) {
-                    return -1;
-                } else if (s1.length() < s2.length()) {
-                    return 1;
-                } else {
-                    return s1.compareTo(s2);
-                }
-            }
-        });
-
-        treeMap.putAll(map);
-        return treeMap;
-    }
-
-    /**
-     * Get headers
-     *
-     * @return the headers
-     */
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
-
-    /**
-     * Add header to headers map
-     * @param key
-     * @param value
-     */
-    public void addHeader(String key, String value) {
-        headers.put(key, value);
-    }
-
-    /**
-     * Get parameters
-     *
-     * @return the parameters
-     */
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
-
-    /**
-     * Add parameter to parameters map
-     * @param key
-     * @param value
-     */
-    public void addParameter(String key, Object value) {
-        parameters.put(key, value);
-    }
-
-    /**
-     * Get request body
-     *
-     * @return the body
-     */
-    public String getBody() {
-        return body;
-    }
-
-    /**
-     * Set request body
-     *
-     * @param body a {@link java.lang.String} object.
-     */
-    public void setBody(String body) {
-        this.body = body;
-    }
-
-    /**
-     * Get template name
-     *
-     * @return the template
-     */
-    public String getTemplate() {
-        return template;
-    }
-
-    /**
-     * Set template name
-     *
-     * @param template the template to set
-     */
-    public void setTemplate(String template) {
-        this.template = template;
-    }
-
-    /**
-     * Get api action path
-     *
-     * @return action path
-     */
-    public String getActionPath() {
-        return requestPath;
-    }
-
-    /**
-     * Set action path
-     * @param path
-     */
-    public void setActionPath(String path) {
-        requestPath = path;
-    }
-
-    /**
-     * Get api action title
-     *
-     * @return title
-     */
-    public String getActionTitle() {
-        return this.getClass().getAnnotation(ApiAction.class).title();
-    }
+	public HTTP getActionMethod() {
+		return this.requestMethod;
+	}
 }

--- a/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
@@ -42,7 +42,7 @@ import ru.sbtqa.tag.datajack.Stash;
 import ru.sbtqa.tag.parsers.core.ParserItem;
 import ru.sbtqa.tag.qautils.properties.Props;
 import ru.sbtqa.tag.qautils.reflect.FieldUtilsExt;
-
+import com.jayway.jsonpath.PathNotFoundException;
 /**
  * Api object (ala Page object). Request to definite url with a set of
  * parameters such as request method, parameters, response validation.
@@ -554,7 +554,7 @@ public abstract class ApiEntry {
 						} catch (InstantiationException | IllegalAccessException | NoSuchMethodException
 								| SecurityException | InvocationTargetException ex) {
 							throw new ApiEntryInitializationException("Could not initialize parser callback", ex);
-						} catch (NoSuchElementException|com.jayway.jsonpath.PathNotFoundException e) {
+						} catch (NoSuchElementException|PathNotFoundException e) {
 							LOG.debug("No such element in callback", e);
 							if (field.getAnnotation(DependentResponseParam.class).necessity()) {
 								throw new NoSuchElementException(e.getMessage());

--- a/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/ApiEntry.java
@@ -542,7 +542,6 @@ public abstract class ApiEntry {
 				} else {
 					Object dependantResponseBody = ApiFactory.getApiFactory().getResponseRepository()
 							.getBody(responseEntry);
-
 					// Use applied parser to get value by path throw the
 					// callback
 					if (ApiFactory.getApiFactory().getParser() != null) {
@@ -555,7 +554,7 @@ public abstract class ApiEntry {
 						} catch (InstantiationException | IllegalAccessException | NoSuchMethodException
 								| SecurityException | InvocationTargetException ex) {
 							throw new ApiEntryInitializationException("Could not initialize parser callback", ex);
-						} catch (NoSuchElementException e) {
+						} catch (NoSuchElementException|com.jayway.jsonpath.PathNotFoundException e) {
 							LOG.debug("No such element in callback", e);
 							if (field.getAnnotation(DependentResponseParam.class).necessity()) {
 								throw new NoSuchElementException(e.getMessage());

--- a/src/main/java/ru/sbtqa/tag/apifactory/ApiFactoryWrapper.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/ApiFactoryWrapper.java
@@ -78,7 +78,6 @@ public class ApiFactoryWrapper {
         }
         if (null == currentEntry) {
             currentEntry = getApiEntry(entriesPackage, title);
-
         }       
         if (null == currentEntry) {
             throw new ApiException("Api entry with title '" + title + "' is not registered");

--- a/src/main/java/ru/sbtqa/tag/apifactory/ApiFactoryWrapper.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/ApiFactoryWrapper.java
@@ -4,11 +4,22 @@ import com.google.common.reflect.ClassPath;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.util.ClassUtils;
+
+import ru.sbtqa.tag.apifactory.annotation.ApiActions;
 import ru.sbtqa.tag.apifactory.annotation.ApiAction;
 import ru.sbtqa.tag.apifactory.exception.ApiEntryInitializationException;
 import ru.sbtqa.tag.apifactory.exception.ApiException;
@@ -52,6 +63,7 @@ public class ApiFactoryWrapper {
         this.responseRepository = new Repository(RepositoryType.RESPONSE);
         this.requestRepository = new Repository(RepositoryType.REQUEST);
     }
+    
 
     /**
      * Get api entry object by title
@@ -67,13 +79,13 @@ public class ApiFactoryWrapper {
         if (null == currentEntry) {
             currentEntry = getApiEntry(entriesPackage, title);
 
-        }
+        }       
         if (null == currentEntry) {
             throw new ApiException("Api entry with title '" + title + "' is not registered");
         }
         return currentEntry;
     }
-
+    
     /**
      * Get api entry by title and packageName
      *
@@ -94,27 +106,102 @@ public class ApiFactoryWrapper {
         } catch (IOException ex) {
             LOG.warn("Failed to shape class info set", ex);
         }
-
-        for (Class<?> entry : allClasses) {
-            if (null != entry.getAnnotation(ApiAction.class)) {
+        ApiEntry entry = getApiEntry(allClasses, title);
+        if(entry!=null){
+        	return entry;
+        }
+        return getApiEntry(getClasses(packageName, loader), title);
+    }
+    private ApiEntry getApiEntry(Set<Class<?>> allClasses, String title) throws ApiException{
+    	for (Class<?> entry : allClasses) {
+    		if (null != entry.getAnnotation(ApiAction.class)) {
                 String entryTitle = entry.getAnnotation(ApiAction.class).title();
                 String entryPath = entry.getAnnotation(ApiAction.class).path();
+          
                 if (entryTitle != null && entryTitle.equals(title)) {
-                    try {
-                        Constructor<ApiEntry> c = (Constructor<ApiEntry>) entry.getConstructor();
-                        currentEntry = c.newInstance();
-                        currentEntryTitle = title;
-                        currentEntryPath = entryPath;
-                        return currentEntry;
-                    } catch (NoSuchMethodException | SecurityException | InstantiationException
-                            | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-                        throw new ApiEntryInitializationException("Can't initialize current entry parameters", ex);
-                    }
+                	 return getApiEntry(entryTitle, entryPath, title, entry);
                 }
             }
-        }
+    		else if(null != entry.getAnnotation(ApiActions.class)){
+    			for(ApiAction apiAction : entry.getAnnotation(ApiActions.class).value()){
+    				String entryTitle = apiAction.title();
+                    String entryPath = apiAction.path();
+                    if(entryTitle != null && entryTitle.equals(title)){
+                    	return getApiEntry(entryTitle, entryPath, title, entry);
+    				}
+    			}
+    		}
+        }	
         return null;
     }
+    
+    private ApiEntry getApiEntry(String entryTitle, String entryPath, String title, Class<?> entry) throws ApiEntryInitializationException {
+    	if (entryTitle != null && entryTitle.equals(title)) {
+            try {
+                Constructor<ApiEntry> c = (Constructor<ApiEntry>) entry.getConstructor();
+                currentEntry = c.newInstance();
+                Method method = getClass().getClassLoader().loadClass("ru.sbtqa.tag.apifactory.ApiEntry").getDeclaredMethod("toApiEntry", String.class);
+                method.invoke(currentEntry, title); 
+                currentEntryTitle = title;
+                currentEntryPath = entryPath;
+                return currentEntry;
+            } catch (NoSuchMethodException | SecurityException | InstantiationException| ClassNotFoundException
+                    | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                throw new ApiEntryInitializationException("Can't initialize current entry parameters", ex);
+            }
+        }
+    	return null;
+    }
+      
+    protected Set<Class<?>> getClasses(String packageName, ClassLoader loader) {
+        MetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory(
+                      loader);   
+        Set<Class<?>> allClasses = new HashSet<>();
+        try {
+               Resource[] resources = scan(loader, packageName);
+               for (Resource resource : resources) {
+                      Class<?> clazz = loadClass(loader, metadataReaderFactory, resource);  
+                      allClasses.add(clazz);
+               }
+               return allClasses;
+        }
+        catch (IOException ex) {
+               throw new IllegalStateException(ex);
+        }
+  }
+
+  private Resource[] scan(ClassLoader loader, String packageName) throws IOException {
+        ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(
+                      loader);
+        String pattern = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX
+                      + ClassUtils.convertClassNameToResourcePath(packageName) + "/**/*.class";
+        Resource[] resources = resolver.getResources(pattern);
+        return resources;
+  }
+
+  private Class<?> loadClass(ClassLoader loader, MetadataReaderFactory readerFactory,
+               Resource resource) {
+        try {
+               MetadataReader reader = readerFactory.getMetadataReader(resource);
+               return ClassUtils.forName(reader.getClassMetadata().getClassName(), loader);
+        }
+        catch (ClassNotFoundException ex) {
+               handleFailure(resource, ex);
+               return null;
+        }
+        catch (LinkageError ex) {
+               handleFailure(resource, ex);
+               return null;
+        }
+        catch (Throwable ex) {        
+               LOG.warn("Unexpected failure when loading class resource " + resource, ex);
+               return null;
+        }
+  }
+
+  private void handleFailure(Resource resource, Throwable ex) {
+        	LOG.warn("Ignoring candidate class resource " + resource + " due to " + ex);  
+  }
 
     /**
      * Returns currently initialized api entry

--- a/src/main/java/ru/sbtqa/tag/apifactory/annotation/ApiAction.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/annotation/ApiAction.java
@@ -1,6 +1,7 @@
 package ru.sbtqa.tag.apifactory.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -10,11 +11,13 @@ import ru.sbtqa.tag.apifactory.rest.HTTP;
 
 /**
  * This annotation used above ApiEntry class declaration
- *
+ * 
  *
  */
+//Повторяющаяся аннатация
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Repeatable(ApiActions.class)
 public @interface ApiAction {
 
     /**

--- a/src/main/java/ru/sbtqa/tag/apifactory/annotation/ApiAction.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/annotation/ApiAction.java
@@ -14,7 +14,7 @@ import ru.sbtqa.tag.apifactory.rest.HTTP;
  * 
  *
  */
-//Повторяющаяся аннатация
+//Повторяющаяся аннотация
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Repeatable(ApiActions.class)

--- a/src/main/java/ru/sbtqa/tag/apifactory/annotation/ApiActions.java
+++ b/src/main/java/ru/sbtqa/tag/apifactory/annotation/ApiActions.java
@@ -1,0 +1,13 @@
+package ru.sbtqa.tag.apifactory.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ApiActions {
+	public ApiAction[] value();
+}

--- a/src/test/resources/config/log4j.properties
+++ b/src/test/resources/config/log4j.properties
@@ -1,8 +1,13 @@
 # Root logger option
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=INFO, stdoutm, AF
  
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+# Output to the console
+log4j.rootLogger=WARN
+log4j.appender.AF=org.apache.log4j.ConsoleAppender
+log4j.appender.AF.layout=org.apache.log4j.SimpleLayout

--- a/src/test/resources/config/log4j.properties
+++ b/src/test/resources/config/log4j.properties
@@ -8,6 +8,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Output to the console
-log4j.rootLogger=WARN
-log4j.appender.AF=org.apache.log4j.ConsoleAppender
-log4j.appender.AF.layout=org.apache.log4j.SimpleLayout
+log4j.appender.info=org.apache.log4j.ConsoleAppender
+log4j.appender.info.Target=System.out
+log4j.appender.info.layout=org.apache.log4j.PatternLayout
+log4j.appender.info.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/test/resources/config/log4j.properties
+++ b/src/test/resources/config/log4j.properties
@@ -8,7 +8,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Output to the console
-log4j.appender.info=org.apache.log4j.ConsoleAppender
-log4j.appender.info.Target=System.out
-log4j.appender.info.layout=org.apache.log4j.PatternLayout
-log4j.appender.info.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.warn=org.apache.log4j.ConsoleAppender
+log4j.appender.warn.Target=System.out
+log4j.appender.warn.layout=org.apache.log4j.PatternLayout
+log4j.appender.warn.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION

1.)Доработана аннотация ApiAction, теперь она повторяющаяся. То есть  теперь мы можем на один и тот же класс вешать множество аннотаций ApiAction.

Пример:
@ApiAction(method = HTTP.POST, path = "corporate/product-selection/rest/v2/uploadScriptsFile", title = "загрузка скрипта c неверной кодировкой", template = "ErrorUploadScriptsFile_cod_UCS-2.json")
@ApiAction(method = HTTP.POST, path = "corporate/product-selection/rest/api/v1.0/uploadScriptsFile", title = "загрузка скрипта v1.0", template = "TM_commonRKO.csv")
@ApiAction(method = HTTP.POST, path = "corporate/product-selection/rest/v2/uploadScriptsFile", title = "загрузка скрипта", template = "testSubsystemCode_testGroupName_autotest1.0.json")
public class UploadScriptsFile extends CookieContainer{...}
2)Добавлена возможность запускать тесты из main. Добавлен пакет с классами src/main/java/cucumber/runtime/io/
Пример вызова:
String[] cucumberOptions = { "--glue", "ru.sbtqa.ufs.efs.api.stepdefinitions", "--no-dry-run", "--monochrome",
                           "classpath:src/test/resources/features", "--tags", tags, "--plugin",
                           "io.qameta.allure.cucumber2jvm.AllureCucumber2Jvm" };
             CucumberStaticRunner.startTests(cucumberOptions);
3) В случае с тестами упакованными в jar, есть проверка на расположение template рядом с jar
4) Если Jar собирается при помощи плагина spring-boot-maven-plugin, то директория классов BOOT-INF/classes, стандартный ClassLoader не подходит. Доработан поиск через Property. Доработан класс ApiFactoryWrapper, метод getApiEntry